### PR TITLE
Fix read roi zip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 sudo: false
 python:
 - "2.7"
-- "3.5"
+- "3.6"
 install:
 - pip install -e .
 before_script:

--- a/ijroi/ijroi.py
+++ b/ijroi/ijroi.py
@@ -125,5 +125,7 @@ def read_roi(fileobj):
 
 def read_roi_zip(fname):
     import zipfile
+    from io import BytesIO
+    
     with zipfile.ZipFile(fname) as zf:
-        return [(n, read_roi(zf.open(n))) for n in zf.namelist()]
+        return[(n, read_roi(BytesIO(zf.read(n)))) for n in zf.namelist()]

--- a/ijroi/tests/test_ijroi.py
+++ b/ijroi/tests/test_ijroi.py
@@ -1,17 +1,17 @@
-import os
-
 import numpy as np
 import py
-import pytest
 
 import ijroi
+
 
 def get_fixture(name):
     dirpath = py.path.local(__file__).dirpath()
     return dirpath.join("fixtures", name)
 
+
 def test_ijroi_import():
     assert ijroi.__version__
+
 
 def test_rectangle():
     fixture = get_fixture("subpixel_rectangle.roi")
@@ -26,6 +26,7 @@ def test_rectangle():
     assert (rect == np.array([[5, 4], [5, 8], [10, 8], [10, 4]])).all()
     assert rect.dtype == np.int16
 
+
 def test_freehand_circle():
     fixture = get_fixture("freehand_circle.roi")
     with fixture.open("rb") as f:
@@ -34,6 +35,7 @@ def test_freehand_circle():
     assert abs(circle[:, 1].mean()-10) < 0.01
     assert abs(circle[:, 0].mean()-15) < 0.01
 
+
 def test_integer_freehand():
     fixture = get_fixture("freehand_integer.roi")
     with fixture.open("rb") as f:
@@ -41,6 +43,7 @@ def test_integer_freehand():
     assert len(freehand) == 3
     assert all(freehand[2, :] == [1, 10])
     assert freehand.dtype == np.int16
+
 
 def test_polygon():
     fixture = get_fixture("polygon_circle.roi")
@@ -57,18 +60,20 @@ def test_polygon():
     assert all(polyint[2, :] == [1, 10])
     assert polyint.dtype == np.int16
 
+
 def test_point():
     fixture = get_fixture("int_point.roi")
     with fixture.open("rb") as f:
         point = ijroi.read_roi(f)
     assert point.ndim == 2
-    assert point[0,0] == 256
-    assert point[0,1] == 128
+    assert point[0, 0] == 256
+    assert point[0, 1] == 128
+
 
 def test_float_point():
     fixture = get_fixture("float_point.roi")
     with fixture.open("rb") as f:
         point = ijroi.read_roi(f)
     assert point.ndim == 2
-    assert abs(point[0,0] - 567.8) < 0.01
-    assert abs(point[0,1] - 123.4) < 0.01
+    assert abs(point[0, 0] - 567.8) < 0.01
+    assert abs(point[0, 1] - 123.4) < 0.01

--- a/ijroi/tests/test_ijroi.py
+++ b/ijroi/tests/test_ijroi.py
@@ -1,12 +1,16 @@
+import zipfile
+
 import numpy as np
 import py
 
 import ijroi
 
 
+FIXTURE_PATH = py.path.local(__file__).dirpath().join("fixtures")
+
+
 def get_fixture(name):
-    dirpath = py.path.local(__file__).dirpath()
-    return dirpath.join("fixtures", name)
+    return FIXTURE_PATH.join(name)
 
 
 def test_ijroi_import():
@@ -77,3 +81,14 @@ def test_float_point():
     assert point.ndim == 2
     assert abs(point[0, 0] - 567.8) < 0.01
     assert abs(point[0, 1] - 123.4) < 0.01
+
+
+def test_zipfile(tmpdir):
+    fixtures = FIXTURE_PATH.listdir("*.roi")
+    zipname = str(tmpdir.join("fixtures.zip"))
+
+    with zipfile.ZipFile(zipname, "w") as z:
+        for fxpath in fixtures:
+            z.write(str(fxpath), fxpath.basename)
+
+    ijroi.read_roi_zip(zipname)

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,5 @@
-# Tox (http://tox.testrun.org/) is a tool for running tests
-# in multiple virtualenvs. This configuration file will run the
-# test suite on all supported python versions. To use it, "pip install tox"
-# and then run "tox" from this directory.
-
 [tox]
-envlist = py27, py35
+envlist = py27, py36
 
 [testenv]
 commands = py.test ijroi


### PR DESCRIPTION
`read_roi_zip()` crashes if `SUB_PIXEL_RESOLUTION` is true because `fileobj.seek()` is not supported for zip files. Zip file object is converted to byte stream in this branch to avoid this problem.

I have not figured out the js file to generate a zip file with subpixel resolution..